### PR TITLE
The content disappears when the sub language cannot be found

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -66,9 +66,7 @@ function autoHighlight(value, options) {
   }
 
   secondBest = normalize({})
-  result = normalize({
-    value: [value]
-  })
+  result = normalize({})
 
   while (++index < length) {
     name = subset[index]
@@ -464,9 +462,6 @@ function coreHighlight(name, value, ignore, prefix, continuation) {
 
   // Build a span.
   function build(name, contents, noPrefix) {
-    if (!name) {
-      return buildText(contents[0])
-    }
     return {
       type: 'element',
       tagName: 'span',

--- a/lib/core.js
+++ b/lib/core.js
@@ -66,7 +66,9 @@ function autoHighlight(value, options) {
   }
 
   secondBest = normalize({})
-  result = normalize({})
+  result = normalize({
+    value: [value]
+  })
 
   while (++index < length) {
     name = subset[index]
@@ -462,6 +464,9 @@ function coreHighlight(name, value, ignore, prefix, continuation) {
 
   // Build a span.
   function build(name, contents, noPrefix) {
+    if (!name) {
+      return buildText(contents[0])
+    }
     return {
       type: 'element',
       tagName: 'span',

--- a/test/fixture/xml-sublanguages-2/input.txt
+++ b/test/fixture/xml-sublanguages-2/input.txt
@@ -1,0 +1,1 @@
+<script>foo()</script>

--- a/test/fixture/xml-sublanguages-2/output.txt
+++ b/test/fixture/xml-sublanguages-2/output.txt
@@ -1,0 +1,1 @@
+<span class="hljs-tag">&#x3C;<span class="hljs-name">script</span>></span>foo()<span class="hljs-tag">&#x3C;/<span class="hljs-name">script</span>></span>


### PR DESCRIPTION
When the sub language is not found, the content disappears.

For example, in HTML script tags, if no keywords appear in the embedded script, the language can not be determined. At this time, the `value` ​​returned from the `highlightAuto` function become an empty array, so the content disappears completely.

```js
const code = `
<script>
  svg4everybody()
</script>
`
console.log(low.highlight('xml', code))
```

I tried to fix it. However, I had to change the interface of the `highlightAuto` function, so I couldn't fix the issue properly.

How should I fix it?