### PR TITLE
Add remaining APIs so that lowlight only needs to provide what it ove…

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -280,6 +280,7 @@ class HastEmitter {
 }
 
 export const lowlight = {
+  ...high,
   highlight,
   highlightAuto,
   registerLanguage,


### PR DESCRIPTION
…rrides

Alternative to #34 / #33 

For me to use highlightjs-glimmer with lowlight, _so far_ `getLanguage` and `inherit` have been identified as missing from lowlight. I figured it might be better to just expose everything, and then only override what lowlight "needs to", ya know?