### PR TITLE
Add `lowlight.registered`

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -135,13 +135,13 @@ function listLanguages() {
 }
 
 /**
- * Get a registered language.
+ * Is an alias or language name registered.
  *
- * @param {string} language Language name
+ * @param {string} aliasOrLanguage alias or language
  * @returns {boolean}
  */
-function registered(language) {
-  return Boolean(high.getLanguage(language))
+function registered(aliasOrLanguage) {
+  return Boolean(high.getLanguage(aliasOrLanguage))
 }
 
 const registerAlias =

--- a/lib/core.js
+++ b/lib/core.js
@@ -139,7 +139,7 @@ function listLanguages() {
  * Get a registered language.
  *
  * @param {string} language Language name
- * @returns {HighlightLanguage}
+ * @returns {HighlightLanguage | undefined}
  */
 function getLanguage(language) {
   return high.getLanguage(language)

--- a/lib/core.js
+++ b/lib/core.js
@@ -4,7 +4,6 @@
  * @typedef {import('highlight.js').HighlightResult} HighlightResult
  * @typedef {import('highlight.js').HLJSOptions} HighlightOptions
  * @typedef {import('highlight.js').LanguageFn} HighlightSyntax
- * @typedef {import('highlight.js').Language} HighlightLanguage
  * @typedef {import('highlight.js').Emitter} HighlightEmitter
  *
  * @typedef {{type: 'element', tagName: 'span', properties: {className: Array.<string>}, children: Array.<LowlightElementSpan|Text>}} LowlightElementSpan
@@ -139,10 +138,10 @@ function listLanguages() {
  * Get a registered language.
  *
  * @param {string} language Language name
- * @returns {HighlightLanguage | undefined}
+ * @returns {boolean}
  */
-function getLanguage(language) {
-  return high.getLanguage(language)
+function registered(language) {
+  return Boolean(high.getLanguage(language))
 }
 
 const registerAlias =
@@ -288,7 +287,7 @@ export const lowlight = {
   highlight,
   highlightAuto,
   registerLanguage,
-  getLanguage,
+  registered,
   listLanguages,
   registerAlias
 }

--- a/lib/core.js
+++ b/lib/core.js
@@ -4,6 +4,7 @@
  * @typedef {import('highlight.js').HighlightResult} HighlightResult
  * @typedef {import('highlight.js').HLJSOptions} HighlightOptions
  * @typedef {import('highlight.js').LanguageFn} HighlightSyntax
+ * @typedef {import('highlight.js').Language} HighlightLanguage
  * @typedef {import('highlight.js').Emitter} HighlightEmitter
  *
  * @typedef {{type: 'element', tagName: 'span', properties: {className: Array.<string>}, children: Array.<LowlightElementSpan|Text>}} LowlightElementSpan
@@ -132,6 +133,16 @@ function registerLanguage(language, syntax) {
  */
 function listLanguages() {
   return high.listLanguages()
+}
+
+/**
+ * Get a registered language.
+ *
+ * @param {string} language Language name
+ * @returns {HighlightLanguage}
+ */
+function getLanguage(language) {
+  return high.getLanguage(language)
 }
 
 const registerAlias =
@@ -277,6 +288,7 @@ export const lowlight = {
   highlight,
   highlightAuto,
   registerLanguage,
+  getLanguage,
   listLanguages,
   registerAlias
 }

--- a/readme.md
+++ b/readme.md
@@ -253,7 +253,7 @@ Is an `alias` or `language` registered.
 
 ###### Returns
 
-`Boolean`.
+`boolean`.
 
 ###### Example
 

--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,7 @@ Try [`refractor`][refractor]!
     *   [`lowlight.highlightAuto(value[, options])`](#lowlighthighlightautovalue-options)
     *   [`lowlight.registerLanguage(language, syntax)`](#lowlightregisterlanguagelanguage-syntax)
     *   [`lowlight.registerAlias(language, alias)`](#lowlightregisteraliaslanguage-alias)
+    *   [`lowlight.registered(aliasOrlanguage)`](#lowlightregisteredaliasorlanguage)
     *   [`lowlight.listLanguages()`](#lowlightlistlanguages)
 *   [Syntaxes](#syntaxes)
 *   [Related](#related)
@@ -239,6 +240,33 @@ lowlight.registerLanguage('markdown', md)
 lowlight.registerAlias({markdown: ['mdown', 'mkdn', 'mdwn', 'ron']})
 lowlight.highlight('mdown', '<em>Emphasis</em>')
 // ^ Works!
+```
+
+### `lowlight.registered(aliasOrlanguage)`
+
+Is an `alias` or `language` registered.
+
+###### Parameters
+
+*   `aliasOrlanguage` (`string`) — [Name][names] of a registered language
+    or its alias
+
+###### Returns
+
+`Boolean`.
+
+###### Example
+
+```js
+import {lowlight} from 'lowlight/lib/core.js'
+import javascript from 'highlight.js/lib/languages/javascript.js'
+
+lowlight.registerLanguage('javascript', javascript)
+
+lowlight.registered('js') // return false
+
+lowlight.registerAlias('javascript', 'js')
+lowlight.registered('js') // return true
 ```
 
 ### `lowlight.listLanguages()`

--- a/test/index.js
+++ b/test/index.js
@@ -384,6 +384,18 @@ test('aliases', (t) => {
   t.end()
 })
 
+test('registered', (t) => {
+  t.deepEqual(lowlight.registered('javascript'), true)
+  t.deepEqual(lowlight.registered('diyjs'), false)
+
+  lowlight.registerAlias('javascript', 'diyjs')
+
+  t.deepEqual(lowlight.registered('diyjs'), true)
+
+  lowlight.registerAlias('javascript', '')
+  t.end()
+})
+
 /**
  * @param {Test} t
  * @param {string} directory


### PR DESCRIPTION
In the following case

```js
// register 'js' as alias of `javascript`
lowlight.registerAlias( 'javascript', 'js' )

// I want to know whether `js` is registered
const hasJSLang = lowlight.listLanguages().indexOf( 'js' ) > -1

// `hasJSLang` is `false` here
if ( hasJSLang ) {
  lowlight.highlight( 'js', code )
} else {
  lowlight.highlightAuto( code )
}
```

`lowhight.listLanguages()` doesn't include `alias`, so there is no method exposed to tell us whether an alias is registered

This problem can be solved by exposing `lowlight.getLanguage`

```js
const hasJSLang = Boolean( lowlight.getLanguage( 'js' ) ) // -> true
```

BTW, I found someone use `highlight.listLanguages` to build a Select component in browser, so I decide to send a PR here rather than [highlight.js](https://github.com/highlightjs/highlight.js) repository