### PR TITLE
Remove use of global highlight instance

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -20,8 +20,11 @@
  * @typedef {Options & ExtraOptions} AutoOptions
  */
 
-import high from 'highlight.js/lib/core'
+import highlightCore from 'highlight.js/lib/core'
 import {fault} from 'fault'
+
+// Create an own instance to not be in conflict with the global object
+const high = highlightCore.newInstance()
 
 const own = {}.hasOwnProperty
 
@@ -65,8 +68,6 @@ function highlight(language, value, options = {}) {
   const result = /** @type {HighlightResult & {_emitter: HastEmitter}} */ (
     high.highlight(value, {language, ignoreIllegals: true})
   )
-
-  high.configure({})
 
   // `highlight.js` seems to use this (currently) for broken grammars, so let’s
   // keep it in there just to be sure.


### PR DESCRIPTION
With this PR we make use of the `newInstance` function of `highlight.js`, to not pollute the global instance anymore. As the configuration is local only now, we don't have to reset it anymore.

Closes #47